### PR TITLE
Set celery timezone as env var.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ x-environment:
   ENABLE_TRELLO_IMPORTER: "False"
   TRELLO_IMPORTER_API_KEY: "api-key-from-trello"
   TRELLO_IMPORTER_SECRET_KEY: "secret-key-from-trello"
+  CELERY_TIMEZONE: 'Europe/Madrid'
 
 
 x-volumes:


### PR DESCRIPTION
Set celery time zone as an environment variable to be worldwide compatible.