### PR TITLE
Link gitlab/github oauth with public registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.0.2 (unreleased)
+
+Add `ENABLE_SLACK`, `ENABLE_GITHUB_AUTH` and `ENABLE_GITLAB_AUTH` environment variables
+
 ## 6.0.1 (2020-02-08)
 
 Adatp to latest

--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ More info about these environment variables [here](https://docs.djangoproject.co
 If you want to allow a public register, configure this variable to "True". By default is "False".
 Should be the same as this var in `taiga-front`.
 
+#### Slack Settings
+
+##### `ENABLE_SLACK`
+
+Enable Slack integration in your Taiga instance. By default is "True". Should have the same value as this variable in taiga-front service.
+
 #### Telemetry Settings
 
 Telemetry anonymous data is collected in order to learn about the use of Taiga and improve the platform based on real scenarios.
@@ -167,17 +173,21 @@ Are used to leave messages in the rabbitmq services. Those variables should be t
 
 #### Github settings
 
-##### `GITHUB_API_CLIENT_ID`, `GITHUB_API_CLIENT_SECRET`
+##### `ENABLE_GITHUB_AUTH`, `GITHUB_API_CLIENT_ID`, `GITHUB_API_CLIENT_SECRET`
 
 Used for login with Github.
 Get these in your profile https://github.com/settings/apps or in your organization profile https://github.com/organizations/{ORGANIZATION-SLUG}/settings/applications
 
+**Note** `ENABLE_GITHUB_AUTH` should have the same value in taiga-back and taiga-front services
+
 #### Gitlab settings
 
-##### `GITLAB_API_CLIENT_ID`, `GITLAB_API_CLIENT_SECRET`, `GITLAB_URL`
+##### `ENABLE_GITLAB_AUTH`, `GITLAB_API_CLIENT_ID`, `GITLAB_API_CLIENT_SECRET`, `GITLAB_URL`
 
 Used for login with GitLab.
 Get these in your profile https://{YOUR-GITLAB}/profile/applications or in your organization profile https://{YOUR-GITLAB}/admin/applications
+
+**Note** `ENABLE_GITLAB_AUTH` should have the same value in taiga-back and taiga-front services
 
 #### Importers
 
@@ -208,15 +218,23 @@ To connect to the events. This should have the same value as `TAIGA_SITES_DOMAIN
 If you want to allow a public register, configure this variable to "true". By default is "false".
 Should be the same as this var in `taiga-back`.
 
-##### `GITHUB_CLIENT_ID`
+##### `ENABLE_GITHUB_AUTH`, `GITHUB_CLIENT_ID`
 
 Used for login with Github.
 Get these in your profile https://github.com/settings/apps or in your organization profile https://github.com/organizations/{ORGANIZATION-SLUG}/settings/applications
 
-##### `GITLAB_CLIENT_ID`, `GITLAB_URL`
+**Note** `ENABLE_GITHUB_AUTH` should have the same value in taiga-back and taiga-front services
+
+##### `ENABLE_GITLAB_AUTH`, `GITLAB_CLIENT_ID`, `GITLAB_URL`
 
 Used for login with GitLab.
 Get these in your profile https://{YOUR-GITLAB}/profile/applications or in your organization profile https://{YOUR-GITLAB}/admin/applications
+
+**Note** `ENABLE_GITLAB_AUTH` should have the same value in taiga-back and taiga-front services
+
+##### `ENABLE_SLACK`
+
+Enable Slack integration in your Taiga instance. By default is "true". Should have the same value as this variable in taiga-back service.
 
 #### Importers
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ version: "3.5"
 
 x-environment:
   &default-back-environment
+  ######################
+  # CONFIGURATION
+  ######################
   # Database settings
   POSTGRES_DB: taiga
   POSTGRES_USER: taiga
@@ -20,26 +23,33 @@ x-environment:
   # EMAIL_PORT: 587
   # EMAIL_HOST_USER: "user"
   # EMAIL_HOST_PASSWORD: "password"
-  # Registration
-  PUBLIC_REGISTER_ENABLED: "False"
-  # Telemetry settings
-  ENABLE_TELEMETRY: "True"
   # Rabbitmq settings
-  # should be the same as in taiga-async-rabbitmq and taiga-events-rabbitmq
+  # Should be the same as in taiga-async-rabbitmq and taiga-events-rabbitmq
   RABBITMQ_USER: taiga
   RABBITMQ_PASS: taiga
+  # Telemetry settings
+  ENABLE_TELEMETRY: "True"
+  ######################
+  # CUSTOMISATION
+  ######################
+  # Registration
+  PUBLIC_REGISTER_ENABLED: "False"
   # Github settings
   # Get these in your profile https://github.com/settings/apps
   # or in your organization profile https://github.com/organizations/{ORGANIZATION-SLUG}/settings/applications
+  ENABLE_GITHUB_AUTH: "False"
   GITHUB_API_CLIENT_ID: "github-api-client-id"
   GITHUB_API_CLIENT_SECRET: "github-api-client-secret"
   # Gitlab settings
   # Get these in your profile https://{YOUR-GITLAB}/profile/applications
   # or in your organization profile https://{YOUR-GITLAB}/admin/applications
+  ENABLE_GITLAB_AUTH: "False"
   GITLAB_API_CLIENT_ID: "gitlab-api-client-id"
   GITLAB_API_CLIENT_SECRET: "gitlab-api-client-secret"
   GITLAB_URL: "gitlab-url"
-  # IMPORTERS
+  # Slack
+  ENABLE_SLACK: "False"
+  # Importers
   ENABLE_GITHUB_IMPORTER: "False"
   GITHUB_IMPORTER_CLIENT_ID: "client-id-from-github"
   GITHUB_IMPORTER_CLIENT_SECRET: "client-secret-from-github"
@@ -107,17 +117,29 @@ services:
   taiga-front:
     image: taigaio/taiga-front:latest
     environment:
+      ######################
+      # CONFIGURATION
+      ######################
       TAIGA_URL: "http://localhost:9000"
       TAIGA_WEBSOCKETS_URL: "ws://localhost:9000"
+      ######################
+      # CUSTOMISATION
+      ######################
       PUBLIC_REGISTER_ENABLED: "false"
+      # Github settings
       # Get these in your profile https://github.com/settings/apps
       # or in your organization profile https://github.com/organizations/{ORGANIZATION-SLUG}/settings/applications
+      ENABLE_GITHUB_AUTH: "false"
       GITHUB_CLIENT_ID: "github-client-id"
+      # Gitlab settings
       # Get these in your profile https://{YOUR-GITLAB}/profile/applications
       # or in your organization profile https://{YOUR-GITLAB}/admin/applications
+      ENABLE_GITLAB_AUTH: "false"
       GITLAB_CLIENT_ID: "gitlab-client-id"
       GITLAB_URL: "gitlab-url"
-      # IMPORTERS
+      # Slack
+      ENABLE_SLACK: "false"
+      # Importers
       ENABLE_GITHUB_IMPORTER: "false"
       ENABLE_JIRA_IMPORTER: "false"
       ENABLE_TRELLO_IMPORTER: "false"


### PR DESCRIPTION
![](https://media.giphy.com/media/jphuDUCPSsC10tEwo0/giphy-downsized.gif)

This PR enforces the link between PUBLIC_REGISTER_ENABLED and Github/Gitlab registration in docker installation. If PUBLIC_REGISTER_ENABLED == False, then it will ignore any configuration about Github/Gitlab.

Bonus track: now you can configure as well if you want Slack plugin or not with `ENABLE_SLACK`

To test:
- [x] check taiga-back and taiga-front changes on configuration
- [x] go to `taiga-back` and `taiga-front` repositories in the ` I/4284/relate_public_register_w_oauth` branch and build both images
- [x] edit the docker-compose.yml and make different combinations of these variables: PUBLIC_REGISTER_ENABLED, ENABLE_GITHUB_AUTH, ENABLE_GITLAB_AUTH. Edit the file and `docker-compose up -d` to test if the changes were applied
- [x] change as well the `ENABLE_SLACK` value and check that it appears/dissapears from the admin panel
- [x] go to taiga-resources and taiga-doc and check the documentation related to the new variables
- [x] merge this PR
- [x] and [this front PR](https://github.com/taigaio/taiga-front/pull/2194)
- [x] and [this back PR](https://github.com/taigaio/taiga-back/pull/1589)
- [x]  and [this doc PR](https://github.com/taigaio/taiga-doc/pull/240)
- [x]  and [this resources PR](https://github.com/taigaio/taiga-resources/pull/14)
- [ ]  and close [this issue](https://tree.taiga.io/project/taiga/issue/4284)