### PR TITLE
Containerize taiga-gateway so it can be used outside of docker-compose.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,11 +123,11 @@ services:
       - taiga
 
   taiga-gateway:
-    image: nginx:1.19-alpine
+    build:
+      context: taiga-gateway
     ports:
       - "9000:80"
     volumes:
-      - ./taiga-gateway/taiga.conf:/etc/nginx/conf.d/default.conf
       - taiga-static-data:/taiga/static
       - taiga-media-data:/taiga/media
     networks:

--- a/taiga-gateway/Dockerfile
+++ b/taiga-gateway/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright (C) 2014-present Taiga Agile LLC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+FROM nginx:1.19-alpine
+LABEL maintainer="support@taiga.io"
+
+COPY ./taiga.conf /etc/nginx/conf.d/default.conf
+


### PR DESCRIPTION
For folks who want to run Taiga in their production orchestration platform (eg. EKS, ECS, etc.) they will need to be able to extract and run `taiga-gateway` as an independent container.

This pull request separates the container into its own Dockerfile, which docker-compose can easily still use. But it can also be easily published and used elsewhere.

See here for a proof of concept arm64 build of `taiga-gateway` using this pull request: https://gallery.ecr.aws/r2d7r3i9/taiga-gateway

See also:
- https://github.com/taigaio/taiga-docker/issues/70
- https://github.com/taigaio/taiga-back/pull/1611