### PR TITLE
doc(docker-installation): #4445 warning to clarify localhost access

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ back instance:
 $ ./taiga-manage.sh [COMMAND]
 ```
 
-Default access for the application is **http://localhost:9000**.
+If you're testing it in your own machine, you can access the application in **http://localhost:9000**. If you're deploying in a server, you'll need to configure hosts and nginx as described later.
 
 ![Taiga screenshot](imgs/taiga.jpg)
 


### PR DESCRIPTION
Includes a warning in the docker installation guide, to clarify the default localhost:9000 access.
- Original issue https://github.com/taigaio/taiga-docker/issues/69
- Taiga's issue: https://tree.taiga.io/project/taiga/issue/4445

> **WARNING**: This PR should be merged in conjunction with:
https://github.com/kaleidos-ventures/taiga-resources/pull/1
https://github.com/kaleidos-ventures/taiga-doc/pull/1

![gif](https://media.giphy.com/media/lOgzjLU2mmN3VoUG4S/giphy.gif)