### PR TITLE
launch-taiga k8s implementation

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,11 @@
+# Taigaio - Kubernetes
+
+Base manifests for `launch-taiga.sh` implementation.
+
+- Ingress implemented on Kubernetes cluster.
+- (Optional) SSL certificate.
+- Gateway instance replaced by Ingress.
+
+## TO-DO
+
+Enhance secret/token management.

--- a/kubernetes/taiga-async-deployment.yaml
+++ b/kubernetes/taiga-async-deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: taiga-async
+  name: taiga-async
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: taiga-async
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: taiga-async
+    spec:
+      containers:
+      - command:
+        - /taiga-back/docker/async_entrypoint.sh
+        env:
+        - name: ENABLE_TELEMETRY
+          valueFrom:
+            configMapKeyRef:
+              key: ENABLE_TELEMETRY
+              name: variables-env  
+        - name: POSTGRES_DB
+          valueFrom:
+            configMapKeyRef:
+              key: POSTGRES_DB
+              name: variables-env  
+        - name: POSTGRES_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: POSTGRES_HOST
+              name: variables-env
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              key: POSTGRES_PASSWORD
+              name: variables-env
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              key: POSTGRES_USER
+              name: variables-env
+        - name: RABBITMQ_PASS
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_PASS
+              name: variables-env
+        - name: RABBITMQ_USER
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_USER
+              name: variables-env
+        - name: TAIGA_SECRET_KEY
+          valueFrom:
+            configMapKeyRef:
+              key: TAIGA_SECRET_KEY
+              name: variables-env
+        - name: TAIGA_SITES_DOMAIN
+          valueFrom:
+            configMapKeyRef:
+              key: TAIGA_SITES_DOMAIN
+              name: variables-env
+        - name: TAIGA_SITES_SCHEME
+          valueFrom:
+            configMapKeyRef:
+              key: TAIGA_SITES_SCHEME
+              name: variables-env
+        image: taigaio/taiga-back:latest
+        imagePullPolicy: ""
+        name: taiga-async
+        resources: {}
+        volumeMounts:
+        - mountPath: /taiga-back/static
+          name: taiga-static-data
+        - mountPath: /taiga-back/media
+          name: taiga-media-data
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes:
+      - name: taiga-static-data
+        persistentVolumeClaim:
+          claimName: taiga-static-data
+      - name: taiga-media-data
+        persistentVolumeClaim:
+          claimName: taiga-media-data
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: taiga-async
+  name: taiga-async
+spec:
+  ports:
+  - name: "5672"
+    port: 5672
+    protocol: TCP
+    targetPort: 5672
+  selector:
+    app: taiga-async

--- a/kubernetes/taiga-async-rabbitmq-data-persistentvolumeclaim.yaml
+++ b/kubernetes/taiga-async-rabbitmq-data-persistentvolumeclaim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: taiga-async-rabbitmq-data  
+  name: taiga-async-rabbitmq-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/kubernetes/taiga-async-rabbitmq-deployment.yaml
+++ b/kubernetes/taiga-async-rabbitmq-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: taiga-async-rabbitmq  
+  name: taiga-async-rabbitmq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: taiga-async-rabbitmq  
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        app: taiga-async-rabbitmq  
+      creationTimestamp: null
+      labels:
+        app: taiga-async-rabbitmq  
+    spec:
+      containers:
+      - env:
+        - name: RABBITMQ_DEFAULT_PASS
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_DEFAULT_PASS
+              name: variables-env
+        - name: RABBITMQ_DEFAULT_USER
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_DEFAULT_USER
+              name: variables-env
+        - name: RABBITMQ_DEFAULT_VHOST
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_DEFAULT_VHOST
+              name: variables-env
+        - name: RABBITMQ_ERLANG_COOKIE
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_ERLANG_COOKIE
+              name: variables-env
+        image: rabbitmq:3-management-alpine
+        name: taiga-async-rabbitmq 
+        imagePullPolicy: ""
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib/rabbitmq
+          name: taiga-async-rabbitmq-data
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes:
+      - name: taiga-async-rabbitmq-data
+        persistentVolumeClaim:
+          claimName: taiga-async-rabbitmq-data
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: taiga-async-rabbitmq  
+  name: taiga-async-rabbitmq
+spec:
+  ports:
+  - name: "5672"
+    port: 5672
+    protocol: TCP
+    targetPort: 5672
+  selector:
+    app: taiga-async-rabbitmq  

--- a/kubernetes/taiga-back-deployment.yaml
+++ b/kubernetes/taiga-back-deployment.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: taiga-back  
+  name: taiga-back
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: taiga-back  
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        app: taiga-back  
+      labels:
+        app: taiga-back  
+    spec:
+      containers:
+      - env:
+        - name: ENABLE_TELEMETRY
+          valueFrom:
+            configMapKeyRef:
+              key: ENABLE_TELEMETRY
+              name: variables-env  
+        - name: POSTGRES_DB
+          valueFrom:
+            configMapKeyRef:
+              key: POSTGRES_DB
+              name: variables-env  
+        - name: POSTGRES_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: POSTGRES_HOST
+              name: variables-env
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              key: POSTGRES_PASSWORD
+              name: variables-env
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              key: POSTGRES_USER
+              name: variables-env
+        - name: RABBITMQ_PASS
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_PASS
+              name: variables-env
+        - name: RABBITMQ_USER
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_USER
+              name: variables-env
+        - name: TAIGA_SECRET_KEY
+          valueFrom:
+            configMapKeyRef:
+              key: TAIGA_SECRET_KEY
+              name: variables-env
+        - name: TAIGA_SITES_DOMAIN
+          valueFrom:
+            configMapKeyRef:
+              key: TAIGA_SITES_DOMAIN
+              name: variables-env
+        - name: TAIGA_SITES_SCHEME
+          valueFrom:
+            configMapKeyRef:
+              key: TAIGA_SITES_SCHEME
+              name: variables-env
+        image: taigaio/taiga-back:latest
+        imagePullPolicy: ""
+        name: taiga-back
+        resources: {}
+        volumeMounts:
+        - mountPath: /taiga-back/static
+          name: taiga-static-data
+        - mountPath: /taiga-back/media
+          name: taiga-media-data
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes:
+      - name: taiga-static-data
+        persistentVolumeClaim:
+          claimName: taiga-static-data
+      - name: taiga-media-data
+        persistentVolumeClaim:
+          claimName: taiga-media-data
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: taiga-back
+  name: taiga-back
+spec:
+  ports:
+  - name: "8000"
+    port: 8000
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app: taiga-back

--- a/kubernetes/taiga-db-data-persistentvolumeclaim.yaml
+++ b/kubernetes/taiga-db-data-persistentvolumeclaim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: taiga-db-data  
+  name: taiga-db-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/kubernetes/taiga-db-deployment.yaml
+++ b/kubernetes/taiga-db-deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: taiga-db  
+  name: taiga-db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: taiga-db
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: taiga-db  
+    spec:
+      containers:
+      - env:
+        - name: POSTGRES_DB
+          valueFrom:
+            configMapKeyRef:
+              key: POSTGRES_DB
+              name: variables-env  
+        - name: POSTGRES_HOST
+          valueFrom:
+            configMapKeyRef:
+              key: POSTGRES_HOST
+              name: variables-env
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              key: POSTGRES_PASSWORD
+              name: variables-env
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              key: POSTGRES_USER
+              name: variables-env
+        image: postgres:12.3
+        imagePullPolicy: ""
+        name: taiga-db
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: taiga-db-data
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes:
+      - name: taiga-db-data
+        persistentVolumeClaim:
+          claimName: taiga-db-data
+status: {}
+---  
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: taiga-db
+  name: taiga-db
+spec:
+  ports:
+  - name: "5432"
+    port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    app: taiga-db  

--- a/kubernetes/taiga-events-deployment.yaml
+++ b/kubernetes/taiga-events-deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: taiga-events
+  name: taiga-events
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: taiga-events
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        app: taiga-events
+      creationTimestamp: null
+      labels:
+        app: taiga-events
+    spec:
+      containers:
+      - env:
+        - name: RABBITMQ_PASS
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_PASS
+              name: variables-env
+        - name: RABBITMQ_USER
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_USER
+              name: variables-env
+        - name: TAIGA_SECRET_KEY
+          valueFrom:
+            configMapKeyRef:
+              key: TAIGA_SECRET_KEY
+              name: variables-env
+        image: taigaio/taiga-events:latest
+        imagePullPolicy: ""
+        name: taiga-events
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: taiga-events
+  name: taiga-events
+spec:
+  ports:
+  - name: "8888"
+    port: 8888
+    protocol: TCP
+    targetPort: 8888
+  selector:
+    app: taiga-events

--- a/kubernetes/taiga-events-rabbitmq-data-persistentvolumeclaim.yaml
+++ b/kubernetes/taiga-events-rabbitmq-data-persistentvolumeclaim.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    app: taiga-events-rabbitmq-data
+  name: taiga-events-rabbitmq-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/kubernetes/taiga-events-rabbitmq-deployment.yaml
+++ b/kubernetes/taiga-events-rabbitmq-deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: taiga-events-rabbitmq  
+  name: taiga-events-rabbitmq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: taiga-events-rabbitmq
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: taiga-events-rabbitmq  
+    spec:
+      containers:
+      - env:
+        - name: RABBITMQ_DEFAULT_PASS
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_DEFAULT_PASS
+              name: variables-env
+        - name: RABBITMQ_DEFAULT_USER
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_DEFAULT_USER
+              name: variables-env
+        - name: RABBITMQ_DEFAULT_VHOST
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_DEFAULT_VHOST
+              name: variables-env
+        - name: RABBITMQ_ERLANG_COOKIE
+          valueFrom:
+            configMapKeyRef:
+              key: RABBITMQ_ERLANG_COOKIE
+              name: variables-env
+        image: rabbitmq:3-management-alpine
+        imagePullPolicy: ""
+        name: taiga-events-rabbitmq
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib/rabbitmq
+          name: taiga-events-rabbitmq-data
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes:
+      - name: taiga-events-rabbitmq-data
+        persistentVolumeClaim:
+          claimName: taiga-events-rabbitmq-data
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: taiga-events-rabbitmq
+  name: taiga-events-rabbitmq
+spec:
+  ports:
+  - name: "5672"
+    port: 5672
+    protocol: TCP
+    targetPort: 5672
+  selector:
+    app: taiga-events-rabbitmq

--- a/kubernetes/taiga-front-deployment.yaml
+++ b/kubernetes/taiga-front-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: taiga-front  
+  name: taiga-front
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: taiga-front  
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: taiga-front  
+    spec:
+      containers:
+      - env:
+        - name: TAIGA_URL
+          valueFrom:
+            configMapKeyRef:
+              key: TAIGA_URL
+              name: variables-env
+        - name: TAIGA_WEBSOCKETS_URL
+          valueFrom:
+            configMapKeyRef:
+              key: TAIGA_WEBSOCKETS_URL
+              name: variables-env
+        image: taigaio/taiga-front:latest
+        imagePullPolicy: ""
+        name: taiga-front
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: taiga-front
+  name: taiga-front
+spec:
+  ports:
+  - name: "80"
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: taiga-front

--- a/kubernetes/taiga-ingress.yaml
+++ b/kubernetes/taiga-ingress.yaml
@@ -8,8 +8,8 @@ spec:
     # Replace by your own domain
     fqdn: taiga6-dev.domain.local
   # Optional   
-  #  tls:
-  #    secretName: certificate-secret
+    tls:
+      secretName: certificate-secret
   routes:
     - conditions:
       - prefix: /static

--- a/kubernetes/taiga-ingress.yaml
+++ b/kubernetes/taiga-ingress.yaml
@@ -1,0 +1,44 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: taiga-ingress
+  namespace: taiga
+spec:
+  virtualhost:
+    # Replace by your own domain
+    fqdn: taiga6-dev.domain.local
+  # Optional   
+  #  tls:
+  #    secretName: certificate-secret
+  routes:
+    - conditions:
+      - prefix: /static
+      services:
+        - name: taiga-back
+          port: 8000
+    - conditions:
+      - prefix: /admin
+      services:
+        - name: taiga-back
+          port: 8000
+    - conditions:
+      - prefix: /api
+      services:
+        - name: taiga-back
+          port: 8000
+    - conditions:
+      - prefix: /media
+      services:
+        - name: taiga-protected
+          port: 8003
+    - conditions:
+      - prefix: /
+      enableWebsockets: true  
+      services:
+        - name: taiga-front
+          port: 80
+    - conditions:
+      - prefix: /events
+      services:
+        - name: taiga-events
+          port: 8888

--- a/kubernetes/taiga-media-data-persistentvolumeclaim.yaml
+++ b/kubernetes/taiga-media-data-persistentvolumeclaim.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    app: taiga-media-data
+  name: taiga-media-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/kubernetes/taiga-protected-deployment.yaml
+++ b/kubernetes/taiga-protected-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: taiga-protected
+  name: taiga-protected
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: taiga-protected
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        app: taiga-protected
+      creationTimestamp: null
+      labels:
+        app: taiga-protected
+    spec:
+      containers:
+      - env:
+        - name: MAX_AGE
+          value: "360"
+        - name: SECRET_KEY
+          valueFrom:
+            configMapKeyRef:
+              key: SECRET_KEY
+              name: variables-env 
+        image: taigaio/taiga-protected:latest
+        imagePullPolicy: ""
+        name: taiga-protected
+        resources: {}
+      restartPolicy: Always
+      serviceAccountName: ""
+      volumes: null
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: taiga-protected
+  name: taiga-protected
+spec:
+  ports:
+  - name: "8003"
+    port: 8003
+    protocol: TCP
+    targetPort: 8003
+  selector:
+    app: taiga-protected

--- a/kubernetes/taiga-static-data-persistentvolumeclaim.yaml
+++ b/kubernetes/taiga-static-data-persistentvolumeclaim.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    app: taiga-static-data  
+  name: taiga-static-data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/kubernetes/variables-env-configmap.yaml
+++ b/kubernetes/variables-env-configmap.yaml
@@ -3,6 +3,14 @@ kind: ConfigMap
 metadata:
   name: variables-env  
 data:
+  #EMAIL_BACKEND: "django.core.mail.backends.smtp.EmailBackend"
+  #DEFAULT_FROM_EMAIL: "no-reply@example.com"
+  #EMAIL_HOST: "smtp.host.example.com"
+  #EMAIL_PORT: 587
+  #EMAIL_HOST_USER: "user"
+  #EMAIL_HOST_PASSWORD: "password"
+  #EMAIL_USE_TLS: "True"
+  #EMAIL_USE_SSL: "True"
   ENABLE_TELEMETRY: "True"
   POSTGRES_DB: "taiga"
   POSTGRES_HOST: "taiga-db"

--- a/kubernetes/variables-env-configmap.yaml
+++ b/kubernetes/variables-env-configmap.yaml
@@ -28,4 +28,4 @@ data:
   TAIGA_SITES_DOMAIN: "taiga6-dev.domain.local"
   TAIGA_SITES_SCHEME: "https"
   TAIGA_URL: "https://taiga6-dev.domain.local"
-  TAIGA_WEBSOCKETS_URL: "ws://taiga6-dev.domain.local"
+  TAIGA_WEBSOCKETS_URL: "wss://taiga6-dev.domain.local"

--- a/kubernetes/variables-env-configmap.yaml
+++ b/kubernetes/variables-env-configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: variables-env  
+data:
+  ENABLE_TELEMETRY: "True"
+  POSTGRES_DB: "taiga"
+  POSTGRES_HOST: "taiga-db"
+  POSTGRES_PASSWORD: "taiga"
+  POSTGRES_USER: "taiga"
+  RABBITMQ_DEFAULT_PASS: "taiga"
+  RABBITMQ_DEFAULT_USER: "taiga"
+  RABBITMQ_DEFAULT_VHOST: "taiga"
+  RABBITMQ_ERLANG_COOKIE: "secret-erlang-cookie"
+  RABBITMQ_PASS: "taiga"
+  RABBITMQ_USER: "taiga"
+  TAIGA_SECRET_KEY: "taiga-back-secret-key"
+  SECRET_KEY: "taiga-back-secret-key"
+  # REPLACE BY YOUR OWN DOMAIN  
+  TAIGA_SITES_DOMAIN: "taiga6-dev.domain.local"
+  TAIGA_SITES_SCHEME: "https"
+  TAIGA_URL: "https://taiga6-dev.domain.local"
+  TAIGA_WEBSOCKETS_URL: "ws://taiga6-dev.domain.local"


### PR DESCRIPTION
Base manifests with Deployments and Services to replicate `launch-taiga.sh` behaviour on Kubernetes clusters..

This PR might indirectly address #76 