### PR TITLE
Addition of an easy backup alternative using docker bind mounts (documentation in seperate pull request)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 db-data
 static-data
+# Uncomment this block if you want to use docker bind mounts for easier backups
+# taiga-bind-mounts/taiga-back
+# taiga-bind-mounts/taiga-db
+# taiga-bind-mounts/taiga-async-rabbitmq
+# taiga-bind-mounts/taiga-events-rabbitmq

--- a/docker-compose-inits.yml
+++ b/docker-compose-inits.yml
@@ -21,6 +21,7 @@ x-volumes:
   # Decomment the next two lines to use bind mounts
   # - ./taiga-bind-mounts/taiga-back/static:/taiga-back/static
   # - ./taiga-bind-mounts/taiga-back/media:/taiga-back/media
+  
   # - ./config.py:/taiga-back/settings/config.py
 
 services:

--- a/docker-compose-inits.yml
+++ b/docker-compose-inits.yml
@@ -19,8 +19,8 @@ x-volumes:
   - taiga-static-data:/taiga-back/static
   - taiga-media-data:/taiga-back/media
   # Decomment the next two lines to use bind mounts
-  # - ./taigadata/taiga-back/static:/taiga-back/static
-  # - ./taigadata/taiga-back/media:/taiga-back/media
+  # - ./taiga-bind-mounts/taiga-back/static:/taiga-back/static
+  # - ./taiga-bind-mounts/taiga-back/media:/taiga-back/media
   # - ./config.py:/taiga-back/settings/config.py
 
 services:

--- a/docker-compose-inits.yml
+++ b/docker-compose-inits.yml
@@ -15,8 +15,12 @@ x-environment:
 
 x-volumes:
   &default-back-volumes
+  # Comment the next two lines to use bind mounts
   - taiga-static-data:/taiga-back/static
   - taiga-media-data:/taiga-back/media
+  # Decomment the next two lines to use bind mounts
+  # - ./taigadata/taiga-back/static:/taiga-back/static
+  # - ./taigadata/taiga-back/media:/taiga-back/media
   # - ./config.py:/taiga-back/settings/config.py
 
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,12 @@ x-environment:
 
 x-volumes:
   &default-back-volumes
+  # Comment the next two lines to use bind mounts
   - taiga-static-data:/taiga-back/static
   - taiga-media-data:/taiga-back/media
+  # Decomment the next two lines to use bind mounts
+  # - ./taigadata/taiga-back/static:/taiga-back/static
+  # - ./taigadata/taiga-back/media:/taiga-back/media
   # - ./config.py:/taiga-back/settings/config.py
 
 
@@ -42,7 +46,10 @@ services:
       POSTGRES_USER: taiga
       POSTGRES_PASSWORD: taiga
     volumes:
+      # Comment the next line to use bind mounts
       - taiga-db-data:/var/lib/postgresql/data
+      # Decomment the next line to use bind mounts
+      # - ./taigadata/taiga-db/data:/var/lib/postgresql/data
     networks:
       - taiga
 
@@ -77,7 +84,10 @@ services:
       RABBITMQ_DEFAULT_PASS: taiga
       RABBITMQ_DEFAULT_VHOST: taiga
     volumes:
+      # Comment the next line to use bind mounts
       - taiga-async-rabbitmq-data:/var/lib/rabbitmq
+      # Decomment the next line to use bind mounts
+      # - ./taigadata/taiga-async-rabbitmq/var/lib/rabbitmq:/var/lib/rabbitmq
     networks:
       - taiga
 
@@ -110,7 +120,10 @@ services:
       RABBITMQ_DEFAULT_PASS: taiga
       RABBITMQ_DEFAULT_VHOST: taiga
     volumes:
+      # Comment the next line to use bind mounts
       - taiga-events-rabbitmq-data:/var/lib/rabbitmq
+      # Decomment the next line to use bind mounts
+      # - ./taigadata/taiga-events-rabbitmq/var/lib/rabbitmq:/var/lib/rabbitmq
     networks:
       - taiga
 
@@ -127,9 +140,14 @@ services:
     ports:
       - "9000:80"
     volumes:
+      # Comment the next three lines to use bind mounts
       - ./taiga-gateway/taiga.conf:/etc/nginx/conf.d/default.conf
       - taiga-static-data:/taiga/static
       - taiga-media-data:/taiga/media
+      # Decomment the next three lines to use bind mounts
+      # ./taigadata/taiga-gateway/taiga.conf:/etc/nginx/conf.d/default.conf
+      # ./taigadata/taiga-back/static:/taiga/static
+      # ./taigadata/taiga-back/media:/taiga/media
     networks:
       - taiga
     depends_on:
@@ -137,6 +155,7 @@ services:
       - taiga-back
       - taiga-events
 
+# Comment the next six lines (the entire volume block) to use bind mounts
 volumes:
   taiga-static-data:
   taiga-media-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ x-volumes:
   # Decomment the next two lines to use bind mounts
   # - ./taigadata/taiga-back/static:/taiga-back/static
   # - ./taigadata/taiga-back/media:/taiga-back/media
+  
   # - ./config.py:/taiga-back/settings/config.py
 
 
@@ -145,9 +146,9 @@ services:
       - taiga-static-data:/taiga/static
       - taiga-media-data:/taiga/media
       # Decomment the next three lines to use bind mounts
-      # ./taigadata/taiga-gateway/taiga.conf:/etc/nginx/conf.d/default.conf
-      # ./taigadata/taiga-back/static:/taiga/static
-      # ./taigadata/taiga-back/media:/taiga/media
+      # - ./taigadata/taiga-gateway/taiga.conf:/etc/nginx/conf.d/default.conf
+      # - ./taigadata/taiga-back/static:/taiga/static
+      # - ./taigadata/taiga-back/media:/taiga/media
     networks:
       - taiga
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,9 @@ x-volumes:
   - taiga-static-data:/taiga-back/static
   - taiga-media-data:/taiga-back/media
   # Decomment the next two lines to use bind mounts
-  # - ./taigadata/taiga-back/static:/taiga-back/static
-  # - ./taigadata/taiga-back/media:/taiga-back/media
-  
+  # - ./taiga-bind-mounts/taiga-back/static:/taiga-back/static
+  # - ./taiga-bind-mounts/taiga-back/media:/taiga-back/media
+
   # - ./config.py:/taiga-back/settings/config.py
 
 
@@ -50,7 +50,7 @@ services:
       # Comment the next line to use bind mounts
       - taiga-db-data:/var/lib/postgresql/data
       # Decomment the next line to use bind mounts
-      # - ./taigadata/taiga-db/data:/var/lib/postgresql/data
+      # - ./taiga-bind-mounts/taiga-db/data:/var/lib/postgresql/data
     networks:
       - taiga
 
@@ -88,7 +88,7 @@ services:
       # Comment the next line to use bind mounts
       - taiga-async-rabbitmq-data:/var/lib/rabbitmq
       # Decomment the next line to use bind mounts
-      # - ./taigadata/taiga-async-rabbitmq/var/lib/rabbitmq:/var/lib/rabbitmq
+      # - ./taiga-bind-mounts/taiga-async-rabbitmq/var/lib/rabbitmq:/var/lib/rabbitmq
     networks:
       - taiga
 
@@ -124,7 +124,7 @@ services:
       # Comment the next line to use bind mounts
       - taiga-events-rabbitmq-data:/var/lib/rabbitmq
       # Decomment the next line to use bind mounts
-      # - ./taigadata/taiga-events-rabbitmq/var/lib/rabbitmq:/var/lib/rabbitmq
+      # - ./taiga-bind-mounts/taiga-events-rabbitmq/var/lib/rabbitmq:/var/lib/rabbitmq
     networks:
       - taiga
 
@@ -146,9 +146,9 @@ services:
       - taiga-static-data:/taiga/static
       - taiga-media-data:/taiga/media
       # Decomment the next three lines to use bind mounts
-      # - ./taigadata/taiga-gateway/taiga.conf:/etc/nginx/conf.d/default.conf
-      # - ./taigadata/taiga-back/static:/taiga/static
-      # - ./taigadata/taiga-back/media:/taiga/media
+      # - ./taiga-bind-mounts/taiga-gateway/taiga.conf:/etc/nginx/conf.d/default.conf
+      # - ./taiga-bind-mounts/taiga-back/static:/taiga/static
+      # - ./taiga-bind-mounts/taiga-back/media:/taiga/media
     networks:
       - taiga
     depends_on:


### PR DESCRIPTION
Hello everybody,

I want to deploy Taiga.io in a production environment using the Docker installation but before I can do so I need to make sure I can backup, update and restore it.

I am sure that I am not the only one in need of

- a clear step-by-step documentation describing backup, update & restore plus
- a simple, tested, low-complexity "one size fits all" way to backup Taiga's data. Be it zipped on ad-hoc basis, rsynced to a network share regularly using a cronjob or just saved to my workstations's desktop via FTP manually before the next big update in case something breaks.

I would like to share my work so everybody can get started quickly using Taiga's docker installation **and** is able to maintain the installation over the years without having to read through the Docker docs in their entirety.

This pull requests adds all the groundwork to make simple backups possible by extending the Docker Compose files while still keeping the defaults compatible with the current default taiga-docker installation. It reduces the complexity for newcomers to apply the easier backup alternative by commenting the relevant parts out while following the associated step-by-step guide.

My second pull-request adds to the documentation explaining volume backup, the easy backup alternative, updating Taiga's docker installation and describing some relevant docker basics along the way: https://github.com/kaleidos-ventures/taiga-resources/pull/3

I tested the added "easy alternative" backup and restore method multiple times to make sure it works.

I hope my pull request to add this for everybody will get accepted.

Feedback is, as always, very welcome!
