### PR TITLE
Temporary fix specifying latest valid image of RabbitMQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.3.0 (unreleased)
 
-- ...
+- Temporary fix specifying latest valid image of RabbitMQ (issue #tg-4700)
 
 ## 6.2.2 (2021-07-15)
 


### PR DESCRIPTION
Original Taiga's [issue](https://tree.taiga.io/project/taiga/issue/4700).

![s](https://media.giphy.com/media/kgaeqKCz7WXjjTKJOn/giphy-downsized.gif)

### What to test

- [x] Review the code

Delete the images and containers of `taiga-events-rabbitmq` and `taiga-async-rabbitmq` services and start Taiga again.
- [x] No error appear in the startup logs. The older ones were:
```
taiga-async-rabbitmq_1   | error: RABBITMQ_DEFAULT_PASS is set but deprecated
taiga-async-rabbitmq_1   | error: RABBITMQ_DEFAULT_USER is set but deprecated
taiga-async-rabbitmq_1   | error: RABBITMQ_DEFAULT_VHOST is set but deprecated
taiga-async-rabbitmq_1   | error: RABBITMQ_ERLANG_COOKIE is set but deprecated
taiga-async-rabbitmq_1   | error: deprecated environment variables detected

taiga-events-rabbitmq_1  | error: RABBITMQ_DEFAULT_PASS is set but deprecated
taiga-events-rabbitmq_1  | error: RABBITMQ_DEFAULT_USER is set but deprecatedt
aiga-events-rabbitmq_1  | error: RABBITMQ_DEFAULT_VHOST is set but deprecated
taiga-events-rabbitmq_1  | error: RABBITMQ_ERLANG_COOKIE is set but deprecated
taiga-events-rabbitmq_1  | error: deprecated environment variables detected
```
- [x] Taiga operates normally, showing no error in the browser's console
