### PR TITLE
Add healthcheck for database

### DIFF
--- a/docker-compose.penpot.yml
+++ b/docker-compose.penpot.yml
@@ -38,8 +38,10 @@ services:
       - penpot_assets_data:/opt/data
 
     depends_on:
-      - penpot-postgres
-      - penpot-redis
+      penpot-postgres:
+        condition: service_healthy
+      penpot-redis:
+        condition: service_started
 
     env_file:
       - docker-compose.penpot.env
@@ -72,6 +74,12 @@ services:
 
     networks:
       - penpot
+
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
 
   penpot-redis:
     image: redis:6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,11 @@ services:
       - taiga-db-data:/var/lib/postgresql/data
     networks:
       - taiga
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
 
   taiga-back:
     image: taigaio/taiga-back:latest
@@ -54,9 +59,12 @@ services:
     networks:
       - taiga
     depends_on:
-      - taiga-db
-      - taiga-events-rabbitmq
-      - taiga-async-rabbitmq
+      taiga-db:
+        condition: service_healthy
+      taiga-events-rabbitmq:
+        condition: service_started
+      taiga-async-rabbitmq:
+        condition: service_started
 
   taiga-async:
     image: taigaio/taiga-back:latest
@@ -66,9 +74,12 @@ services:
     networks:
       - taiga
     depends_on:
-      - taiga-db
-      - taiga-back
-      - taiga-async-rabbitmq
+      taiga-db:
+        condition: service_healthy
+      taiga-back:
+        condition: service_started
+      taiga-async-rabbitmq:
+        condition: service_started
 
   taiga-async-rabbitmq:
     image: rabbitmq:3.8-management-alpine


### PR DESCRIPTION
Fixes #90 

Otherwise, it can happen that the database is not available at the initial setup and `taiga-back` crashes.
To be safe, I added this fix everywhere the Postgres database is being used.