### PR TITLE
chore(settings): use env variables in docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,36 @@
+
+# Taiga's URLs - Variables to define where Taiga should be served
+TAIGA_SCHEME=http  # serve Taiga using "http" or "https" (secured) connection
+TAIGA_DOMAIN=localhost:9000  # Taiga's base URL
+SUBPATH="" # it'll be appended to the TAIGA_DOMAIN (use either "" or a "/subpath")
+WEBSOCKETS_SCHEME=ws  # events connection protocol (use either "ws" or "wss")
+
+# Taiga's Secret Key - Variable to provide cryptographic signing
+SECRET_KEY="taiga-secret-key"  # Please, change it to an unpredictable value!!
+
+# Taiga's Database settings - Variables to create the Taiga database and connect to it
+POSTGRES_USER=taiga  # user to connect to PostgreSQL
+POSTGRES_PASSWORD=taiga  # database user's password
+
+# Taiga's SMTP settings - Variables to send Taiga's emails to the users
+EMAIL_BACKEND=console  # use an SMTP server or display the emails in the console (either "smtp" or "console")
+EMAIL_HOST=smtp.host.example.com  # SMTP server address
+EMAIL_PORT=587   # default SMTP port
+EMAIL_HOST_USER=user  # user to connect the SMTP server
+EMAIL_HOST_PASSWORD=password  # SMTP user's password
+EMAIL_DEFAULT_FROM=changeme@example.com  # default email address for the automated emails
+# EMAIL_USE_TLS/EMAIL_USE_SSL are mutually exclusive (only set one of those to True)
+EMAIL_USE_TLS=True  # use TLS (secure) connection with the SMTP server
+EMAIL_USE_SSL=False  # use implicit TLS (secure) connection with the SMTP server
+
+# Taiga's RabbitMQ settings - Variables to leave messages for the realtime and asynchronous events
+RABBITMQ_USER=taiga  # user to connect to RabbitMQ
+RABBITMQ_PASS=taiga  # RabbitMQ user's password
+RABBITMQ_VHOST=taiga  # RabbitMQ container name
+RABBITMQ_ERLANG_COOKIE=secret-erlang-cookie  # unique value shared by any connected instance of RabbitMQ
+
+# Taiga's Attachments - Variable to define how long the attachments will be accesible
+ATTACHMENTS_MAX_AGE=360  # token expiration date (in seconds)
+
+# Taiga's Telemetry - Variable to enable or disable the anonymous telemetry
+ENABLE_TELEMETRY=True

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.6.0 (Unreleased)
 
 - New .env based configuration docker
+- Control services startup based on healthchecks
 
 ## 6.5.0 (2022-01-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## 6.6.0 (unreleased)
+## 6.6.0 (Unreleased)
 
-- ...
+- New .env based configuration docker
 
 ## 6.5.0 (2022-01-24)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Taiga Docker
 
-&gt; **READ THIS FIRST!**: We recently announced Taiga plans for the future and they greatly affect how we manage this repository and the current Taiga 6 release. Check it [here](https://blog.taiga.io/announcing_taiganext.html).
+| :exclamation: | We recently announced Taiga plans for the future and they greatly affect how we manage this repository and the current Taiga 6 release. Check it [here](https://blog.taiga.io/announcing_taiganext.html).    |
+|---------------|:----|
+
+| :information_source: | You can access the [older docker installation guide](https://docs.taiga.io/setup-production.old.html#setup-prod-with-docker-old) for documentation purposes, intended just for earlier versions of Taiga (prior to ver. 6.6.0)|
+|---------------|:----|
+
+| :information_source: | If you're already using taiga-docker, follow this [migration guide](https://docs.taiga.io/upgrades-docker-migrate.html) to use the new `.env` based deployment. |
+|---------------|:----|
+
 
 ## Getting Started
 
@@ -84,341 +92,413 @@ Every code patch accepted in Taiga codebase is licensed under [MPL 2.0](LICENSE)
 
 Please read carefully [our license](LICENSE) and ask us if you have any questions as well as the [Contribution policy](https://github.com/kaleidos-ventures/taiga-docker/blob/main/CONTRIBUTING.md).
 
-## Configuration and Customisation with Environment Variables
-
-The docker-compose.yml has some environment variables of **configuration** with default values that we strongly recommend to change. Those variables are needed to run Taiga. Find them in the `docker-compose.yml` and `docker-compose-inits.yml`.
-
-**Important** Don't forget to review environment variables in `docker-compose-inits.yml` as some of them are in both files.
-
-Apart from this configuration, you can have some **customisation** in Taiga, and add features that by default are disabled. Find those variables in the **Customisation** section and add the corresponding environment variables whenever you want to enable them.
-
 ## Configuration
 
-### Database configuration
+We've exposed the **Basic configuration** settings in Taiga to an `.env` file. We strongly recommend you to change it, or at least review its content, to avoid using the default values.
 
-These vars will be used to create the database for Taiga and connect to it.
+Both `docker-compose.yml` and `docker-compose-inits.yml` will read from this file to populate their environment variables, so, initially you don't need to change them. Edit these files just in case you require to enable **Additional customization**, or an **Advanced configuration**.
 
-**Important**: these vars should have the same values in `taiga-back` and `taiga-db`.
+Refer to these sections for further information.
 
-**Service: taiga-db**
+## Basic Configuration
 
-```
-POSTGRES_DB: taiga
-POSTGRES_USER: taiga
-POSTGRES_PASSWORD: taiga
-```
+You will find basic **configuration variables** in the `.env` file. As stated before, we encourage you to edit these values, especially those affecting the security.
 
-**Service: taiga-back**
+### Database settings
 
-```
-POSTGRES_DB: taiga
-POSTGRES_USER: taiga
-POSTGRES_PASSWORD: taiga
+These vars are used to create the database for Taiga and connect to it.
+
+```bash
+POSTGRES_USER=taiga  # user to connect to PostgreSQL
+POSTGRES_PASSWORD=taiga  # database user's password
 ```
 
-Additionally, you can also configure `POSTGRES_PORT` in `taiga-back`. Defaults to '5432'.
+### URLs settings
 
-### Taiga Settings
+These vars set where your Taiga instance should be served, and the security protocols to use in the communication layer.
 
-**Service: taiga-back**
-
-The default configuration assumes Taiga is being served in a **subdomain**:
-
-```
-TAIGA_SECRET_KEY: "taiga-back-secret-key"
-TAIGA_SITES_SCHEME: "https"
-TAIGA_SITES_DOMAIN: "taiga.mycompany.com"
-TAIGA_SUBPATH: "/"
+```bash
+TAIGA_SCHEME=http  # serve Taiga using "http" or "https" (secured) connection
+TAIGA_DOMAIN=localhost:9000  # Taiga's base URL
+SUBPATH=""  # it'll be appended to the TAIGA_DOMAIN (use either "" or a "/subpath")
+WEBSOCKETS_SCHEME=ws  # events connection protocol (use either "ws" or "wss")
 ```
 
-If Taiga is being served in a **subpath** instead of a subdomain, the configuration should be something like:
+The default configuration assumes Taiga is being served in a **subdomain**. For example:
 
-```
-TAIGA_SECRET_KEY: "taiga-back-secret-key"
-TAIGA_SITES_SCHEME: "https"
-TAIGA_SITES_DOMAIN: "mycompany.com/taiga"
-TAIGA_SUBPATH: "/taiga" # Mind just one slash
-```
-
-**Service: taiga-front**
-
-The default configuration assumes Taiga is being served in a **subdomain**:
-
-```
-TAIGA_URL: "https://taiga.mycompany.com"
-TAIGA_WEBSOCKETS_URL: "wss://taiga.mycompany.com"
-TAIGA_SUBPATH: "/"
+```bash
+TAIGA_SCHEME=https
+TAIGA_DOMAIN=taiga.mycompany.com
+SUBPATH=""
+WEBSOCKETS_SCHEME=wss
 ```
 
-If Taiga is being served in a **subpath** instead of a subdomain, the configuration should be something like:
+If Taiga is being served in a **subpath**, instead of a subdomain, the configuration should be something like this:
 
-```
-TAIGA_URL: "https://mycompany.com/taiga"
-TAIGA_WEBSOCKETS_URL: "wss://mycompany.com/taiga"
-TAIGA_SUBPATH: "/taiga/" # Mind both slashes
-
-```
-
-**Service: taiga-events**
-
-```
-TAIGA_SECRET_KEY: taiga-back-secret-key
+```bash
+TAIGA_SCHEME=https
+TAIGA_DOMAIN=mycompany.com
+SUBPATH="/taiga"
+WEBSOCKETS_SCHEME=wss
 ```
 
-**Service: taiga-protected**
+### Secret Key settings
 
+This variable allows you to set the secret key in Taiga, used in the cryptographic signing.
+
+```bash
+SECRET_KEY="taiga-secret-key"  # Please, change it to an unpredictable value!
 ```
-SECRET_KEY: "taiga-back-secret-key"
+
+### Email Settings
+
+By default, emails will be printed in the standard output (`EMAIL_BACKEND=console`). If you have your own SMTP service, change it to `EMAIL_BACKEND=smtp` and configure the rest of these variables with the values supplied by your SMTP provider:
+
+```bash
+EMAIL_BACKEND=console  # use an SMTP server or display the emails in the console (either "smtp" or "console")
+EMAIL_HOST=smtp.host.example.com  # SMTP server address
+EMAIL_PORT=587   # default SMTP port
+EMAIL_HOST_USER=user  # user to connect the SMTP server
+EMAIL_HOST_PASSWORD=password  # SMTP user's password
+EMAIL_DEFAULT_FROM=changeme@example.com  # email address for the automated emails
+
+# EMAIL_USE_TLS/EMAIL_USE_SSL are mutually exclusive (only set one of those to True)
+EMAIL_USE_TLS=True  # use TLS (secure) connection with the SMTP server
+EMAIL_USE_SSL=False  # use implicit TLS (secure) connection with the SMTP server
 ```
 
-`TAIGA_SECRET_KEY` is the secret key of Taiga. Should be the same as this var in `taiga-back`, `taiga-events` and `taiga-protected`.
-`TAIGA_URL` is where this Taiga instance should be served. It should be the same as `TAIGA_SITES_SCHEME`://`TAIGA_SITES_DOMAIN`.
-`TAIGA_WEBSOCKETS_URL` is used to connect to the events. This should have the same value as `TAIGA_SITES_DOMAIN`, ie: wss://taiga.mycompany.com.
+### Queue manager settings
 
-### Session Settings
+These variables are used to leave messages in the rabbitmq services.
 
-Taiga doesn't use session cookies in its API as it stateless. However, the Django Admin (`/admin/`) uses session cookie for authentication. By default, Taiga is configured to work behind HTTPS. If you're using HTTP (despite de strong recommendations against it), you'll need to configure the following environment variables so you can access the Admin:
-
-**Service: taiga-back**
-
+```bash
+RABBITMQ_USER=taiga  # user to connect to RabbitMQ
+RABBITMQ_PASS=taiga  # RabbitMQ user's password
+RABBITMQ_VHOST=taiga  # RabbitMQ container name
+RABBITMQ_ERLANG_COOKIE=secret-erlang-cookie  # unique value shared by any connected instance of RabbitMQ
 ```
+
+### Attachments settings
+
+You can configure how long the attachments will be accessible by changing the token expiration timer. After that amount of seconds the token will expire, but you can always get a new attachment url with an active token.
+
+```bash
+ATTACHMENTS_MAX_AGE=360  # token expiration date (in seconds)
+```
+
+### Telemetry Settings
+
+Telemetry anonymous data is collected in order to learn about the use of Taiga and improve the platform based on real scenarios. You may want to enable this to help us shape future Taiga.
+
+```bash
+ENABLE_TELEMETRY=True
+```
+
+You can opt out by setting this variable to False. By default, it's True.
+
+## Additional customization
+
+All these customization options are by default disabled and require you to edit `docker-compose.yml`.
+
+You should add the corresponding environment variables in the proper services with a valid value in order to enable them. Please, do not modify it unless you know what you’re doing.
+
+### Session cookies in Django Admin
+
+Taiga doesn't use session cookies in its API as it stateless. However, the Django Admin (`/admin/`) uses session cookie for authentication. By default, Taiga is configured to work behind HTTPS. If you're using HTTP (despite the strong recommendations against it), you'll need to configure the following environment variables so you can access the Admin:
+
+Service: `taiga-back`
+``` bash
 SESSION_COOKIE_SECURE: "False"
 CSRF_COOKIE_SECURE: "False"
 ```
 
 More info about those variables can be found [here](https://docs.djangoproject.com/en/3.1/ref/settings/#csrf-cookie-secure).
 
-### Email Settings
+### Public registration
 
-By default, email is configured with the _console_ backend, which means that the emails will be shown in the stdout. If you have an smtp service, uncomment the "Email settings" section in `docker-compose.yml` and configure those environment variables:
+If you want to allow a public register, configure this variable to "True". By default it's "False". The value should be the same in `taiga-front` and `taiga-back`.
 
-**Service: taiga-back**
+Service: `taiga-back`
 
-```
-EMAIL_BACKEND: "django.core.mail.backends.smtp.EmailBackend"
-DEFAULT_FROM_EMAIL: "no-reply@mycompany.com"
-EMAIL_HOST: "smtp.host.mycompany.com"
-EMAIL_PORT: 587
-EMAIL_HOST_USER: "user"
-EMAIL_HOST_PASSWORD: "password"
-EMAIL_USE_TLS: "True"
-EMAIL_USE_SSL: "True"
-```
-
-Uncomment `EMAIL_BACKEND` variable, but do not modify unless you know what you're doing.
-
-### Telemetry Settings
-
-Telemetry anonymous data is collected in order to learn about the use of Taiga and improve the platform based on real scenarios.
-
-**Service: taiga-back**
-
-```
-ENABLE_TELEMETRY: "True"
-```
-
-You can opt out by setting this variable to "False". By default is "True".
-
-### Rabbit settings
-
-These variables are used to leave messages in the rabbitmq services. These variables should be the same as in `taiga-back`, `taiga-async`, `taiga-events`, `taiga-async-rabbitmq` and `taiga-events-rabbitmq`.
-
-**Service: taiga-back**
-
-```
-RABBITMQ_USER: taiga
-RABBITMQ_PASS: taiga
-```
-
-Two other variables `EVENTS_PUSH_BACKEND_URL` and `CELERY_BROKER_URL` can also be used to set the events push backend URL and celery broker URL.
-
-```
-EVENTS_PUSH_BACKEND_URL: "amqp://taiga:taiga@taiga-events-rabbitmq:5672/taiga"
-CELERY_BROKER_URL: "amqp://taiga:taiga@taiga-async-rabbitmq:5672/taiga"
-```
-
-**Service: taiga-events**
-
-```
-RABBITMQ_USER: taiga
-RABBITMQ_PASS: taiga
-```
-
-**Service: taiga-async-rabbitmq**
-
-```
-RABBITMQ_ERLANG_COOKIE: secret-erlang-cookie
-RABBITMQ_DEFAULT_USER: taiga
-RABBITMQ_DEFAULT_PASS: taiga
-RABBITMQ_DEFAULT_VHOST: taiga
-```
-
-**Service: taiga-events-rabbitmq**
-
-```
-RABBITMQ_ERLANG_COOKIE: secret-erlang-cookie
-RABBITMQ_DEFAULT_USER: taiga
-RABBITMQ_DEFAULT_PASS: taiga
-RABBITMQ_DEFAULT_VHOST: taiga
-```
-
-### Taiga protected settings
-
-**Service: taiga-protected**
-
-```
-MAX_AGE: 360
-```
-
-The attachments will be accesible with a token during MAX_AGE (in seconds). After that, the token will expire.
-
-## Customisation
-
-All these features are disabled by default. You should add the corresponding environment variables with a proper value to enable them.
-
-### Registration Settings
-
-**Service: taiga-back**
-
-```
+```bash
 PUBLIC_REGISTER_ENABLED: "True"
 ```
 
-**Service: taiga-front**
-
-```
+Service: `taiga-front`
+```bash
 PUBLIC_REGISTER_ENABLED: "true"
 ```
 
-If you want to allow a public register, configure this variable to "True". By default is "False". Should be the same as this var in `taiga-front` and `taiga-back`.
-
 **Important**: Taiga (in its default configuration) disables both Gitlab or Github oauth buttons whenever the public registration option hasn't been activated. To be able to use Github/ Gitlab login/registration, make sure you have public registration activated on your Taiga instance.
 
-### Slack Settings
+### GitHub OAuth login
 
-**Service: taiga-back**
+Used for login with Github.
 
+Follow the [documentation](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app) in Github, when save application Github displays the ID and Secret.
+
+Set variables in docker-compose.yml:
+
+**Note** `ENABLE_GITHUB_AUTH` and `GITHUB_API_CLIENT_ID / GITHUB_CLIENT_ID` should have the same value in `taiga-back` and `taiga-front` services.
+
+Service: `taiga-back`
+```bash
+ENABLE_GITHUB_AUTH: "True"
+GITHUB_API_CLIENT_ID: "github-client-id"
+GITHUB_API_CLIENT_SECRET: "github-client-secret"
+PUBLIC_REGISTER_ENABLED: "True"
 ```
+
+Service: `taiga-front`
+```bash
+ENABLE_GITHUB_AUTH: "true"
+GITHUB_CLIENT_ID: "github-client-id"
+PUBLIC_REGISTER_ENABLED: "true"
+````
+
+### Gitlab OAuth login
+
+Used for login with GitLab.
+
+Follow the [documentation](https://docs.gitlab.com/ee/integration/oauth_provider.html) in Gitlab, when save application GitLab displays the ID and Secret.
+
+Set variables in docker-compose.yml:
+
+**Note** `ENABLE_GITLAB_AUTH`, `GITLAB_API_CLIENT_ID / GITLAB_CLIENT_ID` and `GITLAB_URL` should have the same value in `taiga-back` and `taiga-front` services.
+
+Service: `taiga-back`
+```bash
+ENABLE_GITLAB_AUTH: "True"
+GITLAB_API_CLIENT_ID: "gitlab-client-id"
+GITLAB_API_CLIENT_SECRET: "gitlab-client-secret"
+GITLAB_URL: "gitlab-url"
+PUBLIC_REGISTER_ENABLED: "True"
+```
+
+Service: `taiga-front`
+```bash
+ENABLE_GITLAB_AUTH: "true"
+GITLAB_CLIENT_ID: "gitlab-client-id"
+GITLAB_URL: "gitlab-url"
+PUBLIC_REGISTER_ENABLED: "true"
+```
+
+### Slack integration
+
+Enable Slack integration in your Taiga instance. By default, it's "False". Should have the same value as this variable in `taiga-front` and `taiga-back`.
+
+Service: `taiga-back`
+```bash
 ENABLE_SLACK: "True"
 ```
 
-**Service: taiga-front**
+Service: `taiga-front`
 
 ```
 ENABLE_SLACK: "true"
 ```
 
-Enable Slack integration in your Taiga instance. By default is "False". Should have the same value as this variable in `taiga-front` and `taiga-back`.
+### GitHub importer
 
-### Github settings
-
-Used for login with Github.
-Get these in your profile https://github.com/settings/apps or in your organization profile https://github.com/organizations/{ORGANIZATION-SLUG}/settings/applications
-
-**Note** `ENABLE_GITHUB_AUTH` and `GITHUB_CLIENT_ID` should have the same value in `taiga-back` and `taiga-front` services.
-
-```
-ENABLE_GITHUB_AUTH: "True"
-GITHUB_API_CLIENT_ID: "github-api-client-id"
-GITHUB_API_CLIENT_SECRET: "github-api-client-secret"
-```
-
-**Service: taiga-front**
-
-```
-ENABLE_GITHUB_AUTH: "true"
-GITHUB_API_CLIENT_ID: "github-api-client-id"
-```
-
-### Gitlab settings
-
-Used for login with GitLab.
-Get these in your profile https://{YOUR-GITLAB}/profile/applications or in your organization profile https://{YOUR-GITLAB}/admin/applications
-
-**Note** `ENABLE_GITLAB_AUTH`, `GITLAB_CLIENT_ID` and `GITLAB_URL` should have the same value in `taiga-back` and `taiga-front` services.
-
-**Service: taiga-back**
-
-```
-ENABLE_GITLAB_AUTH: "True"
-GITLAB_API_CLIENT_ID: "gitlab-api-client-id"
-GITLAB_API_CLIENT_SECRET: "gitlab-api-client-secret"
-GITLAB_URL: "gitlab-url"
-```
-
-**Service: taiga-front**
-
-```
-ENABLE_GITLAB_AUTH: "true"
-GITLAB_CLIENT_ID: "gitlab-client-id"
-GITLAB_URL: "gitlab-url"
-```
-
-### Importers
-
-#### Github
-
-**Service: taiga-back**
-
-```
+Service: `taiga-back`
+```bash
 ENABLE_GITHUB_IMPORTER: "True"
 GITHUB_IMPORTER_CLIENT_ID: "client-id-from-github"
 GITHUB_IMPORTER_CLIENT_SECRET: "client-secret-from-github"
 ```
 
-**Service: taiga-front**
-
-```
+Service: `taiga-front`
+```bash
 ENABLE_GITHUB_IMPORTER: "true"
 ```
 
-#### Jira
+### Jira Importer
 
-**Service: taiga-back**
-
-```
+Service: `taiga-back`
+```bash
 ENABLE_JIRA_IMPORTER: "True"
 JIRA_IMPORTER_CONSUMER_KEY: "consumer-key-from-jira"
 JIRA_IMPORTER_CERT: "cert-from-jira"
 JIRA_IMPORTER_PUB_CERT: "pub-cert-from-jira"
 ```
 
-**Service: taiga-front**
-
-```
+Service: `taiga-front`
+```bash
 ENABLE_JIRA_IMPORTER: "true"
 ```
 
-#### Trello
+### Trello importer
 
-**Service: taiga-back**
-
-```
+Service: `taiga-back`
+```bash
 ENABLE_TRELLO_IMPORTER: "True"
 TRELLO_IMPORTER_API_KEY: "api-key-from-trello"
 TRELLO_IMPORTER_SECRET_KEY: "secret-key-from-trello"
 ```
 
-**Service: taiga-front**
-
-```
+Service: `taiga-front`
+```bash
 ENABLE_TRELLO_IMPORTER: "true"
 ```
 
-## Storage
+## Advanced configuration
 
-We have 3 named volumes configured: `taiga-static-data` for statics, `taiga-media-data` for medias and `taiga-db-data` for the database.
+The advanced configuration **will ignore** the environment variables in `docker-compose.yml` or `docker-compose-inits.yml`. Skip this section if you're using env vars.
 
-## Advanced customization (via configuration files)
+It requires you to map the configuration files of `taiga-back` and `taiga-front` services to local files in order to unlock further configuration options.
 
-For a advanced customization, you can use configuration files, mapped to specific directories inside the containers.
+**Map a `config.py` file**
 
-### taiga-back
+From [taiga-back](https://github.com/kaleidos-ventures/taiga-back) download the file `settings/config.py.prod.example` and rename it:
 
-Map a Python configuration file to `/taiga-back/settings/config.py`. You can use [this file](https://raw.githubusercontent.com/kaleidos-ventures/taiga-back/main/docker/config.py) as an example.
+```bash
+mv settings/config.py.prod.example settings/config.py
+```
 
-**Important**: if you use your own configuration file, don't forget to add contribs to `INSTALLED_APPS` (check the example `config.py`).
+Edit `config.py` with your own configuration:
 
-### taiga-front
+- Taiga secret key: **it's important** to change it. It must have the same value as the secret key in `taiga-events` and `taiga-protected`
+- Taiga urls: configure where Taiga would be served using `TAIGA_URL`, `SITES` and `FORCE_SCRIPT_NAME` (see examples below)
+- Connection to PostgreSQL; check `DATABASES` section in the file
+- Connection to RabbitMQ for `taiga-events`; check "EVENTS" section in the file
+- Connection to RabbitMQ for `taiga-async`; check "TAIGA ASYNC" section in the file
+- Credentials for email; check "EMAIL" section in the file
+- Enable/disable anonymous telemetry; check "TELEMETRY" section in the file
 
-Map a `conf.json`configuration file to `/usr/share/nginx/html/conf.json`. You can use [this file](https://raw.githubusercontent.com/kaleidos-ventures/taiga-front/main/docker/conf.json.template) as an example.
+Example to configure Taiga in **subdomain**:
+```python
+TAIGA_SITES_SCHEME = "https"
+TAIGA_SITES_DOMAIN = "taiga.mycompany.com"
+FORCE_SCRIPT_NAME = ""
+```
+
+Example to configure Taiga in **subpath**:
+```python
+TAIGA_SITES_SCHEME = "https"
+TAIGA_SITES_DOMAIN = "taiga.mycompany.com"
+FORCE_SCRIPT_NAME = "/taiga"
+```
+
+Check as well the rest of the configuration if you need to enable some advanced features.
+
+Map the file into `/taiga-back/settings/config.py`. Have in mind that you have to map it both in `docker-compose.yml` and `docker-compose-inits.yml`. You can check the `x-volumes` section in docker-compose.yml with an example.
+
+**Map a `conf.json` file**
+
+From [taiga-front](https://github.com/kaleidos-ventures/taiga-front) download the file `dist/conf.example.json` and rename it:
+
+```bash
+mv dist/conf.example.json dist/conf.json
+```
+
+Edit it with your own configuration:
+
+- Taiga urls: configure where Taiga would be served using `api`, `eventsUrl` and `baseHref` (see examples below)
+
+Example of `conf.json` to serve Taiga in a **subdomain**:
+```json
+{
+    "api": "https://taiga.mycompany.com/api/v1/",
+    "eventsUrl": "wss://taiga.mycompany.com/events",
+    "baseHref": "/",
+```
+
+Example of `conf.json` to serve Taiga in **subpath**:
+```json
+{
+    "api": "https://mycompany.com/taiga/api/v1/",
+    "eventsUrl": "wss://mycompany.com/taiga/events",
+    "baseHref": "/taiga/",
+```
+
+Check as well the rest of the configuration if you need to enable some advanced features.
+
+Map the file into `/taiga-front/dist/config.py`.
+
+## Configure an admin user
+
+```bash
+$ docker-compose up -d
+
+$ docker-compose -f docker-compose.yml -f docker-compose-inits.yml run --rm taiga-manage createsuperuser
+```
+
+## Up and running
+
+Once everything has been installed, launch all the services and check the result:
+
+```bash
+$ docker-compose up -d
+```
+
+## Configure the proxy
+
+Your host configuration needs to make a proxy to `http://localhost:9000`.
+
+If Taiga is being served in a **subdomain**:
+```
+  server {
+      server_name taiga.mycompany.com;
+      
+      location / {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Scheme $scheme;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_redirect off;
+        proxy_pass http://localhost:9000/;
+      }
+      
+      # Events
+      location /events {
+        proxy_pass http://localhost:9000/events;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_connect_timeout 7d;
+        proxy_send_timeout 7d;
+        proxy_read_timeout 7d;
+      }
+  
+      # TLS: Configure your TLS following the best practices inside your company
+      # Logs and other configurations
+  }
+```
+
+If Taiga is being served in a **subpath** instead of a subdomain, the configuration should be something like:
+```
+server {
+  server_name mycompany.com;
+  
+  location /taiga/ {
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Scheme $scheme;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_redirect off;
+    proxy_pass http://localhost:9000/;
+  }
+  
+  # Events
+  location /taiga/events {
+    proxy_pass http://localhost:9000/events;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_connect_timeout 7d;
+    proxy_send_timeout 7d;
+    proxy_read_timeout 7d;
+  }
+  
+  # TLS: Configure your TLS following the best practices inside your company
+  # Logs and other configurations
+}
+```
+
+## Change between subpath and subdomain
+
+If you're changing Taiga configuration from default subdomain (https://taiga.mycompany.com) to subpath (http://mycompany.com/subpath) or vice versa, on top of adjusting the configuration as said above, you should consider changing the TAIGA_SECRET_KEY so the refresh works properly for the end user.

--- a/docker-compose-inits.yml
+++ b/docker-compose-inits.yml
@@ -2,15 +2,13 @@ version: "3.5"
 
 x-environment:
   &default-back-environment
-  POSTGRES_DB: taiga
-  POSTGRES_USER: taiga
-  POSTGRES_PASSWORD: taiga
-  POSTGRES_HOST: taiga-db
-  TAIGA_SECRET_KEY: "taiga-back-secret-key"
-  # these rabbitmq settings should be the same as
-  # in taiga-rabbitmq and taiga-events services
-  RABBITMQ_USER: taiga
-  RABBITMQ_PASS: taiga
+  POSTGRES_DB: "taiga"
+  POSTGRES_USER: "${POSTGRES_USER}"
+  POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+  POSTGRES_HOST: "taiga-db"
+  TAIGA_SECRET_KEY: "${SECRET_KEY}"
+  RABBITMQ_USER: "${RABBITMQ_USER}"
+  RABBITMQ_PASS: "${RABBITMQ_PASS}"
   CELERY_ENABLED: "False"
 
 x-volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,30 +3,29 @@ version: "3.5"
 x-environment:
   &default-back-environment
   # Database settings
-  POSTGRES_DB: taiga
-  POSTGRES_USER: taiga
-  POSTGRES_PASSWORD: taiga
-  POSTGRES_HOST: taiga-db
+  POSTGRES_DB: "taiga"
+  POSTGRES_USER: "${POSTGRES_USER}"
+  POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+  POSTGRES_HOST: "taiga-db"
   # Taiga settings
-  TAIGA_SECRET_KEY: "taiga-back-secret-key"
-  TAIGA_SITES_SCHEME: "http"
-  TAIGA_SITES_DOMAIN: "localhost:9000"
-  TAIGA_SUBPATH: "" # "" or "/subpath"
-  # Email settings. Uncomment following lines and configure your SMTP server
-  # EMAIL_BACKEND: "django.core.mail.backends.smtp.EmailBackend"
-  # DEFAULT_FROM_EMAIL: "no-reply@example.com"
-  # EMAIL_USE_TLS: "False"
-  # EMAIL_USE_SSL: "False"
-  # EMAIL_HOST: "smtp.host.example.com"
-  # EMAIL_PORT: 587
-  # EMAIL_HOST_USER: "user"
-  # EMAIL_HOST_PASSWORD: "password"
+  TAIGA_SECRET_KEY: "${SECRET_KEY}"
+  TAIGA_SITES_SCHEME: "${TAIGA_SCHEME}"
+  TAIGA_SITES_DOMAIN: "${TAIGA_DOMAIN}"
+  TAIGA_SUBPATH: "${SUBPATH}"
+  # Email settings.
+  EMAIL_BACKEND: "django.core.mail.backends.${EMAIL_BACKEND}.EmailBackend"
+  DEFAULT_FROM_EMAIL: "${EMAIL_DEFAULT_FROM}"
+  EMAIL_USE_TLS: "${EMAIL_USE_TLS}"
+  EMAIL_USE_SSL: "${EMAIL_USE_SSL}"
+  EMAIL_HOST: "${EMAIL_HOST}"
+  EMAIL_PORT: "${EMAIL_PORT}"
+  EMAIL_HOST_USER: "${EMAIL_HOST_USER}"
+  EMAIL_HOST_PASSWORD: "${EMAIL_HOST_PASSWORD}"
   # Rabbitmq settings
-  # Should be the same as in taiga-async-rabbitmq and taiga-events-rabbitmq
-  RABBITMQ_USER: taiga
-  RABBITMQ_PASS: taiga
+  RABBITMQ_USER: "${RABBITMQ_USER}"
+  RABBITMQ_PASS: "${RABBITMQ_PASS}"
   # Telemetry settings
-  ENABLE_TELEMETRY: "True"
+  ENABLE_TELEMETRY: "${ENABLE_TELEMETRY}"
 
 x-volumes:
   &default-back-volumes
@@ -34,14 +33,13 @@ x-volumes:
   - taiga-media-data:/taiga-back/media
   # - ./config.py:/taiga-back/settings/config.py
 
-
 services:
   taiga-db:
     image: postgres:12.3
     environment:
-      POSTGRES_DB: taiga
-      POSTGRES_USER: taiga
-      POSTGRES_PASSWORD: taiga
+      POSTGRES_DB: "taiga"
+      POSTGRES_USER: "${POSTGRES_USER}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
     volumes:
       - taiga-db-data:/var/lib/postgresql/data
     networks:
@@ -73,10 +71,10 @@ services:
   taiga-async-rabbitmq:
     image: rabbitmq:3.8-management-alpine
     environment:
-      RABBITMQ_ERLANG_COOKIE: secret-erlang-cookie
-      RABBITMQ_DEFAULT_USER: taiga
-      RABBITMQ_DEFAULT_PASS: taiga
-      RABBITMQ_DEFAULT_VHOST: taiga
+      RABBITMQ_ERLANG_COOKIE: "${RABBITMQ_ERLANG_COOKIE}"
+      RABBITMQ_DEFAULT_USER: "${RABBITMQ_USER}"
+      RABBITMQ_DEFAULT_PASS: "${RABBITMQ_PASS}"
+      RABBITMQ_DEFAULT_VHOST: "${RABBITMQ_VHOST}"
     volumes:
       - taiga-async-rabbitmq-data:/var/lib/rabbitmq
     networks:
@@ -85,9 +83,9 @@ services:
   taiga-front:
     image: taigaio/taiga-front:latest
     environment:
-      TAIGA_URL: "http://localhost:9000"
-      TAIGA_WEBSOCKETS_URL: "ws://localhost:9000"
-      TAIGA_SUBPATH: "" # "" or "/subpath"
+      TAIGA_URL: "${TAIGA_SCHEME}://${TAIGA_DOMAIN}"
+      TAIGA_WEBSOCKETS_URL: "${WEBSOCKETS_SCHEME}://${TAIGA_DOMAIN}"
+      TAIGA_SUBPATH: "${SUBPATH}"
     networks:
       - taiga
     # volumes:
@@ -96,9 +94,9 @@ services:
   taiga-events:
     image: taigaio/taiga-events:latest
     environment:
-      RABBITMQ_USER: taiga
-      RABBITMQ_PASS: taiga
-      TAIGA_SECRET_KEY: "taiga-back-secret-key"
+      RABBITMQ_USER: "${RABBITMQ_USER}"
+      RABBITMQ_PASS: "${RABBITMQ_PASS}"
+      TAIGA_SECRET_KEY: "${SECRET_KEY}"
     networks:
       - taiga
     depends_on:
@@ -107,10 +105,10 @@ services:
   taiga-events-rabbitmq:
     image: rabbitmq:3.8-management-alpine
     environment:
-      RABBITMQ_ERLANG_COOKIE: secret-erlang-cookie
-      RABBITMQ_DEFAULT_USER: taiga
-      RABBITMQ_DEFAULT_PASS: taiga
-      RABBITMQ_DEFAULT_VHOST: taiga
+      RABBITMQ_ERLANG_COOKIE: "${RABBITMQ_ERLANG_COOKIE}"
+      RABBITMQ_DEFAULT_USER: "${RABBITMQ_USER}"
+      RABBITMQ_DEFAULT_PASS: "${RABBITMQ_PASS}"
+      RABBITMQ_DEFAULT_VHOST: "${RABBITMQ_VHOST}"
     volumes:
       - taiga-events-rabbitmq-data:/var/lib/rabbitmq
     networks:
@@ -119,8 +117,8 @@ services:
   taiga-protected:
     image: taigaio/taiga-protected:latest
     environment:
-      MAX_AGE: 360
-      SECRET_KEY: "taiga-back-secret-key"
+      MAX_AGE: "${ATTACHMENTS_MAX_AGE}"
+      SECRET_KEY: "${SECRET_KEY}"
     networks:
       - taiga
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,12 @@ services:
       POSTGRES_DB: "taiga"
       POSTGRES_USER: "${POSTGRES_USER}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 2s
+      timeout: 15s
+      retries: 5
+      start_period: 3s
     volumes:
       - taiga-db-data:/var/lib/postgresql/data
     networks:
@@ -52,9 +58,12 @@ services:
     networks:
       - taiga
     depends_on:
-      - taiga-db
-      - taiga-events-rabbitmq
-      - taiga-async-rabbitmq
+      taiga-db:
+        condition: service_healthy
+      taiga-events-rabbitmq:
+        condition: service_healthy
+      taiga-async-rabbitmq:
+        condition: service_healthy
 
   taiga-async:
     image: taigaio/taiga-back:latest
@@ -64,9 +73,12 @@ services:
     networks:
       - taiga
     depends_on:
-      - taiga-db
-      - taiga-back
-      - taiga-async-rabbitmq
+      taiga-db:
+        condition: service_healthy
+      taiga-events-rabbitmq:
+        condition: service_healthy
+      taiga-async-rabbitmq:
+        condition: service_healthy
 
   taiga-async-rabbitmq:
     image: rabbitmq:3.8-management-alpine
@@ -75,6 +87,12 @@ services:
       RABBITMQ_DEFAULT_USER: "${RABBITMQ_USER}"
       RABBITMQ_DEFAULT_PASS: "${RABBITMQ_PASS}"
       RABBITMQ_DEFAULT_VHOST: "${RABBITMQ_VHOST}"
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 2s
+      timeout: 15s
+      retries: 5
+      start_period: 3s
     volumes:
       - taiga-async-rabbitmq-data:/var/lib/rabbitmq
     networks:
@@ -100,7 +118,8 @@ services:
     networks:
       - taiga
     depends_on:
-      - taiga-events-rabbitmq
+      taiga-events-rabbitmq:
+        condition: service_healthy
 
   taiga-events-rabbitmq:
     image: rabbitmq:3.8-management-alpine
@@ -109,6 +128,12 @@ services:
       RABBITMQ_DEFAULT_USER: "${RABBITMQ_USER}"
       RABBITMQ_DEFAULT_PASS: "${RABBITMQ_PASS}"
       RABBITMQ_DEFAULT_VHOST: "${RABBITMQ_VHOST}"
+    healthcheck:
+      test: rabbitmq-diagnostics -q ping
+      interval: 2s
+      timeout: 15s
+      retries: 5
+      start_period: 3s
     volumes:
       - taiga-events-rabbitmq-data:/var/lib/rabbitmq
     networks:


### PR DESCRIPTION
![gif](https://media.giphy.com/media/jdO5221aQufi69T3rT/giphy.gif)

Changes in this PR:
- Centralize most common env vars from `docker-compose.yml` to an .env file to abstract complexity
- Update these changes in the doc (README)
- Fix docker services dependencies on startup introducing healthchecks