### PR TITLE
Added healthcheck for taiga-events-rabbitmq

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,8 @@ services:
     networks:
       - taiga
     depends_on:
-      - taiga-events-rabbitmq
+      taiga-events-rabbitmq:
+        condition: service_healthy
 
   taiga-events-rabbitmq:
     image: rabbitmq:3.8-management-alpine
@@ -111,6 +112,8 @@ services:
       RABBITMQ_DEFAULT_USER: taiga
       RABBITMQ_DEFAULT_PASS: taiga
       RABBITMQ_DEFAULT_VHOST: taiga
+    healthcheck:
+      test: "rabbitmq-diagnostics is_running"
     volumes:
       - taiga-events-rabbitmq-data:/var/lib/rabbitmq
     networks:


### PR DESCRIPTION
This fixes https://github.com/kaleidos-ventures/taiga-docker/issues/44 "[BUG] taiga-events_1 container failing #44", where the service taiga-events would start up before the required container taiga-events-rabbitmq was in ready status, resulting in a failure of the taiga-events-***** container every time a docker-compose up was run.

With the following changes taiga-events will wait until the taiga-events-rabbitmq service is completely healthy before starting.
This also means the _docker compose up_ command will wait for the rabbitmq container to be in a healthy state, as well as the containers that depend on taiga-events such as taiga-back and taiga-gateway. From our tests this means it will wait about 30 seconds every time the _docker compose up_ is run.